### PR TITLE
Correct typo "Defalut" to "Default" on GET L3 instance in nsm_l3_diagram_create.py

### DIFF
--- a/network-sketcher_online/ns_engine/nsm_l3_diagram_create.py
+++ b/network-sketcher_online/ns_engine/nsm_l3_diagram_create.py
@@ -715,7 +715,7 @@ class  nsm_l3_diagram_create():
                             self._l3_if_has_l3_segment_set.add(tuple(_m))
 
         ### GET L3 instance
-        self.defalut_l3_instance_name = 'Defalut'
+        self.default_l3_instance_name = 'Default'
         self.l3_instance_array = []
         self.update_l3_instance_array = []
         for tmp_update_l3_table_array in self.update_l3_table_array:
@@ -733,8 +733,8 @@ class  nsm_l3_diagram_create():
                         self.update_l3_instance_array.append([tmp_update_l3_table_array,tmp_update_l3_table_array[3]])
                         #print([tmp_update_l3_table_array,tmp_update_l3_table_array[3]])
                     else:
-                        self.update_l3_instance_array.append([tmp_update_l3_table_array, self.defalut_l3_instance_name])
-                        #print([tmp_update_l3_table_array, self.defalut_l3_instance_name])
+                        self.update_l3_instance_array.append([tmp_update_l3_table_array, self.default_l3_instance_name])
+                        #print([tmp_update_l3_table_array, self.default_l3_instance_name])
 
         #print('--- self.update_l3_instance_array ---')
         #print(self.update_l3_instance_array)


### PR DESCRIPTION
Correct typo "Defalut" to "Default" on GET L3 instance

## Description

Correct a typo so L3 diagrams show "Default" instead of "Defalut" on 

## Type of Change

- [ ] Bug Fix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (please describe)

<!-- TODO: Update the link below to point to your project's contributing guidelines -->
- [x] I have read the [contributing guidelines](/CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
